### PR TITLE
Adapt fields to IEEE 802.1AS-2020

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from setuptools import setup
 
 ROOT_DIR = Path(os.path.join(os.path.dirname(__file__)))
-PACKAGE_VERSION = f'{0}.{1}.{0}'
+PACKAGE_VERSION = f'{1}.{0}.{0}'
 
 
 def readme():


### PR DESCRIPTION
Formerly this warning was hindering usage of this module:

/usr/lib/python3/dist-packages/scapy/base_classes.py:319: SyntaxWarning: Packet 'PTPv2' has a duplicated 'reserved3' field ! If you are using several ConditionalFields, have a look at MultipleTypeField instead ! This will become a SyntaxError in a future version of Scapy !

With this change, the package field are adapted to comply with IEEE 802.1AS-2020 and the above warning is implicitely removed.
