### PR TITLE
Fix default packet not being printable

### DIFF
--- a/gptp/layers.py
+++ b/gptp/layers.py
@@ -35,7 +35,7 @@ class PTPv2(Packet):
         FlagsField("flags", 0, 16, FLAGS),
         LongField("correctionField", 0),
         XIntField("messageTypeSpecific", 0),
-        PortIdentityField("sourcePortIdentity", 0),
+        PortIdentityField("sourcePortIdentity", None),
         ShortField("sequenceId", 0),
         XByteField("controlField", 0),
         SignedByteField("logMessageInterval", -3),


### PR DESCRIPTION
Default constructing a PTPv2 packet and then using `.show()` results in a `TypeError` since the default value for the field `sourcePortIdentity` is 0, but is expected to be an array of 10 bytes. There is already handling behaviour for the case when this field is `None`, so default-initialising to `None` fixes the issue. 

Using Scapy 2.6.0, Python 3.12.7 

```
Python 3.12.7 (main, Oct  1 2024, 02:05:46) [Clang 15.0.0 (clang-1500.3.9.4)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from gptp.layers import PTPv2
>>> x = PTPv2()
>>> x.show()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/alexandere/scapy_venv/lib/python3.12/site-packages/scapy/packet.py", line 1518, in show
    return self._show_or_dump(dump, indent, lvl, label_lvl)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/alexandere/scapy_venv/lib/python3.12/site-packages/scapy/packet.py", line 1484, in _show_or_dump
    reprval = f.i2repr(self, fvalue)
              ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/alexandere/scapy_examples/scapy-gptp/gptp/fields.py", line 54, in i2repr
    return self.i2h(pkt, x)
           ^^^^^^^^^^^^^^^^
  File "/Users/alexandere/scapy_examples/scapy-gptp/gptp/fields.py", line 50, in i2h
    p = struct.unpack(self.encoding, val)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: a bytes-like object is required, not 'int'
```