### PR TITLE
Fix empty wheel distribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+
+## [0.2.1] - 2025-02-07
+
+### Fixed
+
+- Build configuration leading to empty whl distribution (#6)
+
 
 ## [0.2.0] - 2024-12-04
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,4 +40,4 @@ build-backend = "hatchling.build"
 packages = ["src/gptp"]
 
 [tool.hatch.build.targets.sdist]
-packages = ["src/gptp"]
+include = ["src/gptp"]


### PR DESCRIPTION
# Summary

- An erroneous configuration in the `[hatch.build.targets]` lead to the resulting wheel distribution being empty. This PR fixes the configuration to make both sdist and wheel distributions work.
- Bump package version to `0.2.1`

## References

- Fixes #6 

## Kudos

- Thanks to @sfaiss for reporting
